### PR TITLE
Add environment variable to hold OWM API Key

### DIFF
--- a/src/segments/owm.go
+++ b/src/segments/owm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -22,6 +23,8 @@ type Owm struct {
 }
 
 const (
+	// APIEnv environment variable that holds the openweathermap api key
+	APIEnv properties.Property = "apienv"
 	// APIKey openweathermap api key
 	APIKey properties.Property = "apikey"
 	// Location openweathermap location
@@ -74,11 +77,16 @@ func (d *Owm) getResult() (*owmDataResponse, error) {
 		}
 	}
 
+	apiEnv := d.props.GetString(APIEnv, "")
 	apikey := d.props.GetString(APIKey, ".")
 	location := d.props.GetString(Location, "De Bilt,NL")
 	units := d.props.GetString(Units, "standard")
 	httpTimeout := d.props.GetInt(properties.HTTPTimeout, properties.DefaultHTTPTimeout)
 	d.URL = fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?q=%s&units=%s&appid=%s", location, units, apikey)
+
+	if apiEnv != "" {
+		apikey = os.Getenv(apiEnv)
+	}
 
 	body, err := d.env.HTTPRequest(d.URL, nil, httpTimeout)
 	if err != nil {

--- a/website/docs/segments/owm.mdx
+++ b/website/docs/segments/owm.mdx
@@ -37,6 +37,7 @@ The free tier for _Current weather and forecasts collection_ is sufficient.
 
 | Name            | Type     | Description                                                                                                                                                                                                        |
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apienv`        | `string` | Environment variable that contains your API key [Open Weather Map][owm]                                                                                                                                                                          |
 | `apikey`        | `string` | Your API key from [Open Weather Map][owm]                                                                                                                                                                          |
 | `location`      | `string` | The requested location. Formatted as <City,STATE,COUNTRY_CODE>. City name, state code and country code divided by comma. Please, refer to ISO 3166 for the state codes or country codes - defaults to `DE BILT,NL` |
 | `units`         | `string` | Units of measurement. Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit) - defaults to `standard`                                                                                 |


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Add the ability to use an environment variable to set the OWM API key

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
